### PR TITLE
Add one-off holidays

### DIFF
--- a/src/Rekurzia/SlovakHolidays.php
+++ b/src/Rekurzia/SlovakHolidays.php
@@ -38,6 +38,11 @@ class SlovakHolidays
 		'monday' => 'Veľkonočný pondelok'
 	];
 
+	/** @var array */
+	private static $oneOffHolidays = [
+		'2018-10-30' => '100. výročie prijatia Deklarácie slovenského národa'
+	];
+
 	/**
 	 * Constructor to disable instantiation
 	 * @throws SlovakHolidaysException
@@ -65,6 +70,14 @@ class SlovakHolidays
 
 		foreach (self::$fixedHolidays as $key => $holiday) {
 			$holidays[$year . '-' . $key] = $holiday;
+		}
+
+		foreach (self::$oneOffHolidays as $key => $holiday) {
+			$date = date_parse($key);
+
+			if ($date['year'] === $year) {
+				$holidays[$key] = $holiday;
+			}
 		}
 
 		ksort($holidays);

--- a/tests/SlovakHolidays.test.phpt
+++ b/tests/SlovakHolidays.test.phpt
@@ -5,6 +5,27 @@ require __DIR__ . '/bootstrap.php';
 use Tester\Assert;
 use Rekurzia\SlovakHolidays;
 
+Assert::same(true, SlovakHolidays::isDayHoliday(2018, 10, 30));
+Assert::same(false, SlovakHolidays::isDayHoliday(2017, 10, 30));
+Assert::same([
+	'2018-01-01',
+	'2018-01-06',
+	'2018-03-30',
+	'2018-04-02',
+	'2018-05-01',
+	'2018-05-08',
+	'2018-07-05',
+	'2018-08-29',
+	'2018-09-01',
+	'2018-09-15',
+	'2018-10-30',
+	'2018-11-01',
+	'2018-11-17',
+	'2018-12-24',
+	'2018-12-25',
+	'2018-12-26',
+], array_keys(SlovakHolidays::getHolidays(2018)));
+
 Assert::exception(function() {
 	new SlovakHolidays;
 }, 'Rekurzia\SlovakHolidaysException', 'Class cannot be instantiated');


### PR DESCRIPTION
According to the [recent amendments](https://spravy.pravda.sk/domace/clanok/483929-poslanci-odobrili-jednorazovy-statny-sviatok-bude-nim-30-oktober/), there will be one-off holiday on 30. 10. 2018.